### PR TITLE
Add scrolling homepage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,33 @@
-
 import ActorsGraph from './components/ActorsGraph'
+import ActorsList from './components/ActorsList'
+import ArgumentsSection from './components/ArgumentsSection'
+import ScrollSection from './components/ScrollSection'
+import Timeline from './components/Timeline'
 
 function App() {
-  
   return (
     <div className="container">
-      <div className="content-container">
-        <h1>Bienvenue</h1>
-        <p>Ceci est un site sur la controverse des voitures autonomes</p>
-      </div>
-      <ActorsGraph />
+      <ScrollSection className="intro">
+        <h1>Voitures autonomes : quelles controverses ?</h1>
+        <p>
+          Les promesses de l\'autonomie s\'accompagnent de questionnements sur la
+          sécurité, l\'emploi et la protection des données. Cette page présente
+          les principaux acteurs et arguments de ce débat.
+        </p>
+      </ScrollSection>
+      <Timeline />
+      <ScrollSection>
+        <h2>Les acteurs</h2>
+        <ActorsList />
+      </ScrollSection>
+      <ScrollSection>
+        <h2>Arguments clés</h2>
+        <ArgumentsSection />
+      </ScrollSection>
+      <ScrollSection>
+        <h2>Cartographie des relations</h2>
+        <ActorsGraph />
+      </ScrollSection>
     </div>
   )
 }

--- a/src/components/ActorsList.tsx
+++ b/src/components/ActorsList.tsx
@@ -1,0 +1,17 @@
+import actorGraphData from '../data/actorsData'
+
+function ActorsList() {
+  return (
+    <div className="actors-list">
+      {actorGraphData.nodes.map(actor => (
+        <div key={actor.id} className="actor-card">
+          <img src={actor.image} alt={actor.name} />
+          <h3>{actor.name}</h3>
+          <p>{actor.description}</p>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+export default ActorsList

--- a/src/components/ArgumentsSection.tsx
+++ b/src/components/ArgumentsSection.tsx
@@ -1,0 +1,19 @@
+import actorGraphData from '../data/actorsData'
+
+function ArgumentsSection() {
+  const args = Array.from(
+    new Set(actorGraphData.nodes.flatMap(actor => actor.arguments)),
+  )
+
+  return (
+    <ul className="arguments-list">
+      {args.map((arg, index) => (
+        <li key={index} className="argument-item">
+          {arg}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default ArgumentsSection

--- a/src/components/ScrollSection.tsx
+++ b/src/components/ScrollSection.tsx
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from 'react'
+
+interface ScrollSectionProps {
+  children: React.ReactNode
+  className?: string
+}
+
+function ScrollSection({ children, className }: ScrollSectionProps) {
+  const ref = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node) return
+
+    const observer = new IntersectionObserver(entries => {
+      entries.forEach(entry => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('visible')
+        }
+      })
+    }, { threshold: 0.2 })
+
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  return (
+    <section ref={ref} className={`scroll-section ${className ?? ''}`}>
+      {children}
+    </section>
+  )
+}
+
+export default ScrollSection

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,0 +1,23 @@
+import ScrollSection from './ScrollSection'
+
+const events = [
+  { date: '2010', description: 'premiers développements des voitures autonomes' },
+  { date: '2016', description: 'tests sur route ouverte' },
+  { date: '2020', description: 'accidents médiatisés et débats éthiques' },
+  { date: '2024', description: 'discussions réglementaires intensifiées' },
+]
+
+function Timeline() {
+  return (
+    <ScrollSection className="timeline">
+      <div className="timeline-line" />
+      {events.map(event => (
+        <div key={event.date} className="timeline-item">
+          <strong>{event.date}</strong> {event.description}
+        </div>
+      ))}
+    </ScrollSection>
+  )
+}
+
+export default Timeline

--- a/src/index.css
+++ b/src/index.css
@@ -120,3 +120,69 @@ h3 {
   z-index: 2;
   pointer-events: none;
 }
+.scroll-section {
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity 0.6s ease-out, transform 0.6s ease-out;
+  margin: 4rem 0;
+}
+
+.scroll-section.visible {
+  opacity: 1;
+  transform: none;
+}
+
+.timeline {
+  position: fixed;
+  top: 20%;
+  right: 1rem;
+  width: 220px;
+}
+
+.timeline-line {
+  position: absolute;
+  left: 20px;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: #ccc;
+}
+
+.timeline-item {
+  position: relative;
+  margin: 2rem 0;
+  padding-left: 40px;
+}
+
+.timeline-item::before {
+  content: '';
+  position: absolute;
+  left: 15px;
+  top: 0;
+  width: 10px;
+  height: 10px;
+  background: #000;
+  border-radius: 50%;
+}
+
+.actors-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.actor-card {
+  background: #f9f9f9;
+  padding: 1rem;
+  border: 1px solid #eee;
+  border-radius: 5px;
+}
+
+.actor-card img {
+  width: 80px;
+  height: auto;
+  margin-bottom: 0.5rem;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}


### PR DESCRIPTION
## Summary
- implement new scroll reveal component
- add timeline, actors list and arguments sections
- show components on homepage
- style new components

## Testing
- `npm run build`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6846eb8d5ff08324a37d2fe25750cfe0