### PR TITLE
feat/app-add-full-page-introduction

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,12 @@
 
 import ActorsGraph from './components/ActorsGraph'
+import Introduction from './components/Introduction'
 
 function App() {
   
   return (
     <div className="container">
-      <div className="content-container">
-        <h1>Bienvenue</h1>
-        <p>Ceci est un site sur la controverse des voitures autonomes</p>
-      </div>
+      <Introduction />
       <ActorsGraph />
     </div>
   )

--- a/src/components/Introduction.tsx
+++ b/src/components/Introduction.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+function Introduction() {
+  return (
+    <section className="introduction-container">
+      <h1 className="introduction-title">
+        VOITURES AUTONOMES :<br />LA FIN DE LA ROUTE POUR LES HUMAINS ?
+      </h1>
+      <p className="introduction-description">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+      </p>
+    </section>
+  )
+}
+
+export default Introduction

--- a/src/index.css
+++ b/src/index.css
@@ -120,3 +120,21 @@ h3 {
   z-index: 2;
   pointer-events: none;
 }
+.introduction-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  text-align: center;
+}
+
+.introduction-title {
+  font-size: 2rem;
+  text-transform: uppercase;
+  margin-bottom: 1rem;
+}
+
+.introduction-description {
+  max-width: 600px;
+}


### PR DESCRIPTION
## Summary
- add Introduction component
- style introduction for full page layout
- show introduction before the graph

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6847080e2e3883249c0020a17201cacb