### PR TITLE
feat/components-add-actor-section

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 
 import ActorsGraph from './components/ActorsGraph'
+import ActorSection from './components/ActorSection'
 
 function App() {
   
@@ -10,6 +11,7 @@ function App() {
         <p>Ceci est un site sur la controverse des voitures autonomes</p>
       </div>
       <ActorsGraph />
+      <ActorSection />
     </div>
   )
 }

--- a/src/components/ActorSection.tsx
+++ b/src/components/ActorSection.tsx
@@ -1,0 +1,56 @@
+import { useState } from 'react'
+import actorGraphData from '../data/actorsData'
+import type { Actor } from '../models/actor/actor'
+import { ProgressBar } from './ProgressBar'
+
+const opinionColors: Record<string, string> = {
+  'Farouchement opposés': '#e53e3e',
+  'Plutôt défavorable': '#dd6b20',
+  Prudents: '#d69e2e',
+  Neutres: '#4a5568',
+  'Partisan convaincu': '#38a169',
+}
+
+function ActorSection() {
+  const actors = actorGraphData.nodes
+  const [index, setIndex] = useState(0)
+
+  const actor = actors[index] as Actor
+  const opinionColor = opinionColors[actor.opinion] ?? '#718096'
+
+  return (
+    <div className="actor-section">
+      <img src={actor.image} alt={actor.name} className="actor-section-image" />
+      <div className="actor-section-info">
+        <h2>{actor.name}</h2>
+        <div className="actor-section-opinion" style={{ backgroundColor: opinionColor }}>
+          {actor.opinion}
+        </div>
+        <ProgressBar
+          value={actor.engagement}
+          text={`Engagement : ${Math.round(actor.engagement * 100)}%`}
+        />
+        <p className="actor-section-description">{actor.description}</p>
+        <h3>Arguments</h3>
+        <ul className="actor-section-arguments">
+          {actor.arguments.map((arg, i) => (
+            <li key={i}>{arg}</li>
+          ))}
+        </ul>
+        <div className="actor-section-controls">
+          <button disabled={index === 0} onClick={() => setIndex(i => Math.max(0, i - 1))}>
+            Précédent
+          </button>
+          <button
+            disabled={index === actors.length - 1}
+            onClick={() => setIndex(i => Math.min(actors.length - 1, i + 1))}
+          >
+            Suivant
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ActorSection

--- a/src/index.css
+++ b/src/index.css
@@ -120,3 +120,41 @@ h3 {
   z-index: 2;
   pointer-events: none;
 }
+.actor-section {
+  display: flex;
+  align-items: flex-start;
+  gap: 2rem;
+  margin: 2rem 0;
+}
+
+.actor-section-image {
+  width: 200px;
+  height: auto;
+}
+
+.actor-section-info {
+  flex: 1;
+  text-align: left;
+}
+
+.actor-section-opinion {
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+}
+
+.actor-section-description {
+  margin-bottom: 1rem;
+}
+
+.actor-section-arguments {
+  list-style: square;
+  padding-left: 1rem;
+}
+
+.actor-section-controls {
+  margin-top: 1rem;
+  display: flex;
+  gap: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- add `ActorSection` component to display actors one by one
- style layout for actor section in CSS
- render new section in `App`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684708a40bb08324b9298a05a20f895a