### PR TITLE
[FEAT] Resize graph

### DIFF
--- a/src/components/ActorsGraph.tsx
+++ b/src/components/ActorsGraph.tsx
@@ -18,8 +18,24 @@ function ActorsGraph() {
   >
 
   const MAX_NODE_SIZE = 20; // Maximum node size
-
   const [selectedActor, setSelectedActor] = useState<Actor | null>(null)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const [dimensions, setDimensions] = useState({width: 0, height: 0})
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const resizeObserver = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        const { width, height } = entry.contentRect;
+        setDimensions({ width, height });
+      }
+    });
+
+    resizeObserver.observe(container);
+    return () => resizeObserver.disconnect();
+  }, [])
 
   const drawNode = (
     node: NodeObject<Actor>,
@@ -85,19 +101,24 @@ function ActorsGraph() {
   }, []);
 
   return (
-    <div className="graph-container">
-      <ForceGraph2D<Actor, Link>
-        ref={fgRef}
-        graphData={actorGraphData}
-        nodeLabel={node => `${node.name} - ${node.opinion}`}
-        nodeCanvasObject={drawNode}
-        nodeRelSize={MAX_NODE_SIZE}
-        linkWidth={1}
-        minZoom={2}
-        maxZoom={4}
-        onNodeClick={node => setSelectedActor(node as Actor)}
-        onBackgroundClick={() => setSelectedActor(null)}
-      />
+    <div className="graph-container" ref={containerRef}>
+      <h1 className="graph-title">Cartographie Controverse</h1>
+      {dimensions.width > 0 && dimensions.height > 0 && (
+          <ForceGraph2D<Actor, Link>
+            ref={fgRef}
+            width={dimensions.width}
+            height={dimensions.height}
+            graphData={actorGraphData}
+            nodeLabel={node => `${node.name} - ${node.opinion}`}
+            nodeCanvasObject={drawNode}
+            nodeRelSize={MAX_NODE_SIZE}
+            linkWidth={1}
+            minZoom={2}
+            maxZoom={4}
+            onNodeClick={node => setSelectedActor(node as Actor)}
+            onBackgroundClick={() => setSelectedActor(null)}
+          />
+      )}
       <ActorSidebar actor={selectedActor} onClose={() => setSelectedActor(null)} />
     </div>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -19,7 +19,22 @@ body {
 
 .graph-container {
   position: relative;
-  height: 600px;
+  height: 100vh;
+  margin: 0 10rem;
+}
+
+.force-graph-canvas {
+  width: 100% !important;
+  height: 100% !important;
+  display: block;
+  position: absolute;
+  top: 0;
+  left: 0;  
+}
+
+.force-graph-container {
+  margin-top: 2rem;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.10);
 }
 
 .sidebar {


### PR DESCRIPTION
This pull request introduces enhancements to the `ActorsGraph` component, focusing on responsiveness and layout improvements. The changes include implementing dynamic resizing for the graph container, adding a title to the graph, and updating styles for better visual presentation.

### Functional Enhancements:
* **Dynamic resizing for graph container**: Added a `ResizeObserver` to monitor container size changes and update dimensions dynamically, enabling responsive graph rendering. (`src/components/ActorsGraph.tsx`, [src/components/ActorsGraph.tsxL21-R38](diffhunk://#diff-1e0afa1ee7c09174958f5bcf959fb9ff55788e09f9e86fcb3f67c8e518985ddfL21-R38))
* **Conditional rendering of the graph**: Ensured the graph is only rendered when valid dimensions are available, improving performance and preventing layout issues. (`src/components/ActorsGraph.tsx`, [src/components/ActorsGraph.tsxL88-R110](diffhunk://#diff-1e0afa1ee7c09174958f5bcf959fb9ff55788e09f9e86fcb3f67c8e518985ddfL88-R110))

### UI Improvements:
* **Added graph title**: Included a descriptive title, "Cartographie Controverse," to enhance user understanding of the graph's purpose. (`src/components/ActorsGraph.tsx`, [src/components/ActorsGraph.tsxL88-R110](diffhunk://#diff-1e0afa1ee7c09174958f5bcf959fb9ff55788e09f9e86fcb3f67c8e518985ddfL88-R110))
* **Updated CSS for responsiveness and styling**: Changed `.graph-container` height to `100vh` for full-screen responsiveness, added margins, and introduced styles for `.force-graph-canvas` and `.force-graph-container` to improve layout and appearance. (`src/index.css`, [src/index.cssL22-R37](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eL22-R37))