### PR TITLE
[FIX] prevent burger menu from opening when hidden

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -15,7 +15,9 @@ function Navbar() {
     const targetElement = document.querySelector(targetId);
     if (!targetElement) return;
 
-    toggleHamburger();
+    // Close the hamburger menu if it's open
+    if (hamburgerOpen)
+      toggleHamburger();
 
     targetElement.scrollIntoView({ behavior: "smooth" });
     document.body.style.overflow = ""; // Reset overflow to default


### PR DESCRIPTION
This pull request includes a small change to the `Navbar` component in `src/components/Navbar.tsx`. The change ensures that the hamburger menu is closed if it is open before scrolling to the target element.