### PR TITLE
[FIX] Change terminology card style

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -618,6 +618,7 @@ a {
   background: white;
   color: black;
   font-weight: bold;
+  text-align: center;
 }
 .flip-card-back {
   background: white;

--- a/src/index.css
+++ b/src/index.css
@@ -550,6 +550,7 @@ a {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
   gap: 24px;
+  justify-items: center;
 }
 
 @media (max-width: 768px) {

--- a/src/index.css
+++ b/src/index.css
@@ -616,6 +616,7 @@ a {
 .flip-card-front {
   background: white;
   color: black;
+  font-weight: bold;
 }
 .flip-card-back {
   background: white;


### PR DESCRIPTION
This pull request makes minor styling adjustments to the `src/index.css` file, improving layout alignment and text emphasis.

Styling improvements:

* Added `justify-items: center` to the grid layout to center-align items within the grid. (`[src/index.cssR553](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eR553)`)
* Applied `font-weight: bold` to `.flip-card-front` to emphasize the text on the front of flip cards. (`[src/index.cssR620](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eR620)`)